### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -104,7 +104,7 @@ class syntax_plugin_exttab1 extends DokuWiki_Syntax_Plugin {
      @var   $mytable    the code that will be inserted into the document
      @return true, if rendering happens, false in all other cases
     */
-    function render($mode, &$renderer, $data)
+    function render($mode, Doku_Renderer $renderer, $data)
     {
         if ($mode == 'xhtml' && strlen($data[0]) > 1) {
             $rawdata = explode("\n", $data[0]);


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
